### PR TITLE
fix: Drop template dependency

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -21,10 +21,6 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.2.0"
-    }
     time = {
       source  = "hashicorp/time"
       version = "~> 0.10.0"


### PR DESCRIPTION
With c921f2c003d32bedb85097d4ce63b7ecb88a7313, all usages of the template provider's `template_file` were replaced with `templatefile`, which is part of Terraform > 0.12, hence the provider is not required anymore.

Since the template provider is deprecated, it's not available on non-x86ish architectures, causing the whole terraform-hcloud-k3s module to be unusable on them.

Example error message:
```
╷
│ Error: Incompatible provider version
│ 
│ Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a package available for your current platform, darwin_arm64.
│ 
│ Provider releases are separate from Terraform CLI releases, so not all providers are available for all platforms. Other versions of this provider may have different platforms supported.
╵
```