### PR TITLE
fix: add gateway public IP to tls-san

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -106,6 +106,7 @@ locals {
   EOT
   control_plane_arguments          = <<-EOT
   --tls-san="${hcloud_server_network.gateway.ip}" \
+  --tls-san="${hcloud_server.gateway.ipv4_address}" \
   --flannel-backend=none \
   --disable-kube-proxy \
   --disable-network-policy \

--- a/locals.tf
+++ b/locals.tf
@@ -107,6 +107,7 @@ locals {
   control_plane_arguments          = <<-EOT
   --tls-san="${hcloud_server_network.gateway.ip}" \
   --tls-san="${hcloud_server.gateway.ipv4_address}" \
+  --tls-san="${hcloud_server.gateway.ipv6_address}" \
   --flannel-backend=none \
   --disable-kube-proxy \
   --disable-network-policy \


### PR DESCRIPTION
> Originally part of #86

## Summary
- include the gateway public IPv4 address in the k3s API server TLS SAN list