### PR TITLE
fix: migrate hcloud_server network blocks from network_id to subnet_id (hcloud v1.63.0)

### DIFF
--- a/gateway.tf
+++ b/gateway.tf
@@ -111,8 +111,8 @@ resource "hcloud_server" "gateway" {
 
   # Network needs to be present twice for some unknown reason :-/
   network {
-    network_id = hcloud_network.private.id
-    ip         = cidrhost(hcloud_network_subnet.subnet.ip_range, 1)
+    subnet_id = hcloud_network_subnet.subnet.id
+    ip        = cidrhost(hcloud_network_subnet.subnet.ip_range, 1)
   }
 }
 

--- a/node_pool/pool.tf
+++ b/node_pool/pool.tf
@@ -108,7 +108,7 @@ resource "hcloud_server" "pool" {
   }
 
   network {
-    network_id = var.hcloud_network_id
+    subnet_id = var.hcloud_subnet_id
   }
 }
 
@@ -318,8 +318,8 @@ variable "ssh_keys" {
   type        = list(string)
 }
 
-variable "hcloud_network_id" {
-  description = "IP Network id."
+variable "hcloud_subnet_id" {
+  description = "ID of the network subnet to attach the server to."
   type        = string
 }
 

--- a/node_pool_cluster_init.tf
+++ b/node_pool_cluster_init.tf
@@ -31,7 +31,7 @@ module "node_pool_cluster_init" {
   network_interface                   = each.value.network_interface
   ssh_keys                            = [for k in hcloud_ssh_key.pub_keys : k.name]
   firewall_ids                        = each.value.any.is_control_plane ? var.control_plane_firewall_ids : var.worker_node_firewall_ids
-  hcloud_network_id                   = hcloud_network.private.id
+  hcloud_subnet_id                    = hcloud_network_subnet.subnet.id
   enable_public_net_ipv4              = var.enable_public_net_ipv4
   enable_public_net_ipv6              = var.enable_public_net_ipv6
   default_gateway                     = local.default_gateway

--- a/node_pools.tf
+++ b/node_pools.tf
@@ -28,7 +28,7 @@ module "node_pools" {
   network_interface                   = each.value.network_interface
   ssh_keys                            = [for k in hcloud_ssh_key.pub_keys : k.name]
   firewall_ids                        = each.value.any.is_control_plane ? var.control_plane_firewall_ids : var.worker_node_firewall_ids
-  hcloud_network_id                   = hcloud_network.private.id
+  hcloud_subnet_id                    = hcloud_network_subnet.subnet.id
   enable_public_net_ipv4              = var.enable_public_net_ipv4
   enable_public_net_ipv6              = var.enable_public_net_ipv6
   default_gateway                     = local.default_gateway


### PR DESCRIPTION
## Summary

Fixes the `terraform plan` failure introduced by the hcloud provider v1.63.0 upgrade (Renovate PR #102).

hcloud provider v1.63.0 added `subnet_id` support to `hcloud_server` inline `network {}` blocks ([PR #1278](https://github.com/hetznercloud/terraform-provider-hcloud/pull/1278)), making `network_id` and `subnet_id` **mutually exclusive**. The existing code uses `network_id`, but the provider now populates `subnet_id` in state (as empty string), causing the conflict.

## Changes

- `node_pool/pool.tf`: `network { subnet_id = var.hcloud_subnet_id }` (was `network_id`); variable renamed from `hcloud_network_id` to `hcloud_subnet_id`
- `gateway.tf`: inline `network {}` block uses `subnet_id = hcloud_network_subnet.subnet.id`
- `node_pool_cluster_init.tf`: passes `hcloud_subnet_id = hcloud_network_subnet.subnet.id`
- `node_pools.tf`: passes `hcloud_subnet_id = hcloud_network_subnet.subnet.id`

**Not changed**: `hcloud_server_network` and `hcloud_network_route` resources — they still correctly use `network_id`.

## Verification

`terraform fmt node_pool_cluster_init.tf node_pools.tf node_pool/pool.tf gateway.tf`
`terraform validate` passes.

Fixes #109